### PR TITLE
Add default handling when key is not in json response

### DIFF
--- a/binance/exceptions.py
+++ b/binance/exceptions.py
@@ -11,8 +11,8 @@ class BinanceAPIException(Exception):
         except ValueError:
             self.message = 'Invalid JSON error message from Binance: {}'.format(response.text)
         else:
-            self.code = json_res['code']
-            self.message = json_res['msg']
+            self.code = json_res.get('code')
+            self.message = json_res.get('msg')
         self.status_code = status_code
         self.response = response
         self.request = getattr(response, 'request', None)


### PR DESCRIPTION
When Binance API is sending an unexpected response text, it sometimes doesn't have "code" or "msg" fields in the response and thus the following exception occurs:

`File "/usr/local/lib/python3.8/dist-packages/binance/exceptions.py", line 14, in __init__ self.code = json_res['code'] KeyError: 'code'`

This patch is to add a default handling when key is not present in JSON response.

